### PR TITLE
Set rate limiting

### DIFF
--- a/manifest_template.yml
+++ b/manifest_template.yml
@@ -53,18 +53,18 @@ apigee:
             value:
               {{ NAME }}:
                 quota:
+                  enabled: false
+                spikeArrest:
+                  enabled: false
+              app:
+                quota:
                   enabled: true
-                  limit: 300
+                  limit: 1500
                   interval: 1
                   timeunit: minute
                 spikeArrest:
                   enabled: true
-                  ratelimit: 600pm # 10 requests per second
-              app:
-                quota:
-                  enabled: false
-                spikeArrest:
-                  enabled: false
+                  ratelimit: 1500pm # 25 requests per second
         description: {{ DESCRIPTION }}
         displayName: {{ TITLE }}
         environments: [ {{ ENV.name }} ]


### PR DESCRIPTION
Changed from proxy-level rate limiting to app-level rate limiting. The main Aggregator proxy uses proxy-level rate limiting because there is only one app that uses it, i.e. the NHS App. As the Reporting Service will be made available to multiple integrating parties, each will use a separate app. Each of those apps needs to be rate-limited individually. 

Set rate-limiting quota to 1500 request per minute to meet the 25tps per integrating party NFR. Note: Apigee does not allow setting of rate limits per second, only per minute. Set spike arrest to double the rate limit following the established pattern used by the main Aggregator proxy of double the rate limit.